### PR TITLE
Don't execute shell as a programme explicitly

### DIFF
--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -183,9 +183,9 @@ function createHgScript(normalizedPath, hookName, npmScriptName, verifyMessage)
           try:
             FNULL = os.open(os.devnull, os.O_WRONLY)
             if show_output:
-              return subprocess.check_call(cmd, stdin=FNULL, shell=True) == 0
+              return subprocess.check_call(cmd, stdin=FNULL) == 0
             else:
-              return subprocess.check_call(cmd, stdin=FNULL, stdout=FNULL, stderr=FNULL, shell=True) == 0
+              return subprocess.check_call(cmd, stdin=FNULL, stdout=FNULL, stderr=FNULL) == 0
           except (OSError, subprocess.CalledProcessError) as e:
             print_error_msg(str(e))
             return False


### PR DESCRIPTION
It actually addresses issue #9 which I encounter myself.

According to reference on [Popen](https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen), for both Windows and POSIX systems it works more predictable with a default value of `shell=False`. And for none of the systems it gives any apparent benefit. While it gives adds [some risk](https://docs.python.org/3.7/library/subprocess.html#security-considerations), which might not be of concern in our case but still exist.